### PR TITLE
RFC: Bootstrap RFC process

### DIFF
--- a/000-example/proposal.md
+++ b/000-example/proposal.md
@@ -1,0 +1,49 @@
+> This is a fairly open-ended template; feel free to remove any sections that
+> you can't really fill out just yet.
+
+# Summary
+
+> Summarize your change.
+
+
+# Motivation
+
+> Describe the problem that this change intends to solve. Don't get into how it
+> solves it yet.
+>
+> This can be brief, but if there is any additional context or any
+> empathy-building that you'd like to communicate, it can't hurt to include it
+> with plenty of detail and hypothetical examples.
+
+
+# Proposal
+
+> Describe your proposal.
+>
+> Things that can help: clearly defining terms, providing example content,
+> pseudocode, etc.
+>
+> Feel free to mention key implementation concerns.
+
+
+# Open Questions
+
+> Raise any concerns here for things you aren't sure about yet.
+
+
+# Answered Questions
+
+> If there were any major concerns that have already (or eventually, through
+> the RFC process) reached consensus, it can still help to include them along
+> with their resolution, if it's otherwise unclear.
+>
+> This can be especially useful for RFCs that have taken a long time and there
+> were some subtle yet important details to get right.
+>
+> This may very well be empty if the proposal is simple enough.
+
+
+# New Implications
+
+> What is the impact of this change, outside of the change itself? How might it
+> change peoples' workflows today, good or bad?

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,26 @@ users and contributors. RFCs enable the community to collaborate during the
 architecture and feature design process, before getting to code and
 implementation.
 
+An RFC may not be necessary for changes that are narrow enough in scope with
+limited impact to the rest of Concourse. If you feel that this is the case, you
+can cut straight to submitting a PR, though it's still a good idea to have an
+issue opened first to provide additional context. Do note however that pull
+requests and issues may be closed with a polite request to submit an RFC first.
+
+If you're not sure whether to open an RFC for a change you'd like to propose,
+feel free to discuss beforehand in [Discord](https://discord.gg/MeRxXKW) - just
+ping \code{@rfc-czars} or guauge interest in \code{#contributors}.
+
 
 ## Providing feedback to an RFC
 
 This process is centered around pull requests. Feedback and questions should be
 left as comments on specific lines of the pull request's proposal document, so
-that they can be marked as resolved. This is to avoid an ever-growing comment
-thread at the top level.
+that they can be marked as resolved. This is to avoid an ever-growing sequence
+of comments at the top level.
+
+Top-level comments and pull-request reviews are allowed for overarching
+commentary, but in general line-wise comments are preferred.
 
 
 ## Submitting an RFC

--- a/README.md
+++ b/README.md
@@ -1,1 +1,111 @@
 # Concourse RFCs
+
+> A process for collaborating on the design for substantial changes to Concourse.
+
+
+## What should be proposed as an RFC?
+
+RFCs should be opened for changes that have a substantial impact on Concourse
+users and developers. The RFC process enables us to collaborate during the
+design process, before we get to code and implementation.
+
+An important goal of this process is to keep a record of the decision-making
+process as a proposal evolves. This is done via the pull request review and
+commenting system. This allows discussions to be marked as "resolved", rather
+than wrangling an ever-growing comment chain on a GitHub issue.
+
+
+## RFC Process
+
+1. Fork this repository.
+1. Copy the `000-example` RFC template, naming it something like
+   `123-my-proposal`.
+  * Don't worry too much about the number; they don't have to be sequential.
+    You can try to predict your pull request number for example, and/or just
+    edit it after submitting.
+1. Write your RFC in `proposal.md` under your RFC directory.
+    * Try to outline the motivation for the proposal first. A proposal with
+      no context is more likely to fall under scrutiny.
+    * Having a summary near the beginning of the proposal is also helpful.
+    * Take special care to think about any risks or drawbacks to your proposal
+      ahead-of-time. These have to be assessed at some point! If you're not
+      sure how to resolve them, leave them under an "open questions" section,
+      and we can all try to work through them together.
+1. Submit a pull request. Your proposal may include any dependent assets
+   (example content, screenshots) under its RFC directory. For convenience,
+   link to the rendered proposal in the pull request body, like so:
+
+   ```
+   [Rendered](https://github.com/{YOUR NAME}/rfcs/blob/{YOUR BRANCH}/123-my-proposal/proposal.md)
+   ```
+
+   Try to keep the description light, since most content should be in the
+   `proposal.md` already. But feel free to reference any relevant GitHub
+   issues, since that helps with context-building.
+1. Each RFC will be assigned to at least one reviewer. Feel free to reach out
+   to them if you need help on any part of the process or with the proposal
+   itself.
+1. Community members are expected to submit feedback by leaving comments on
+   lines in the pull request and submitting reviews. This allows conversations
+   to be marked "resolved" and prevents the comment history on the pull request
+   from growing larger and larger.
+  * As the RFC author, feel free to leave your own comments/feedback, using the
+    pull request as a "captain's log" as you think about the problem more and
+    reach key decisions. The point of all this is to have a clear public record
+    for the decision-making process.
+1. Amendments to the RFC should be made by pushing more commits to the RFC
+   branch. **Please do not rebase and force-push over your own commits.**
+   Instead, try to make meaningful commits that summarize their changes.
+
+
+### Resolution
+
+Once consensus builds and things slow down, the RFC will be granted with one of
+the following labels:
+
+* `resolution/merge`: there are no outstanding objections to the RFC and
+  implementation can begin as soon as the RFC is merged.
+* `resolution/postpone`: there are no outstanding objections to the RFC, but we
+  have decided to defer its implementation until some time in the future, and
+  until then it's better to leave the proposal unmerged in case things change
+  by the time we can get to implementation.
+* `resolution/close`: we have decided not to accept the RFC, and have no plans
+  for implementation.
+
+These labels mark the beginning of the final phase of the RFC. During this
+point, any additional feedback will be sought out by communicating it on our
+[blog](https://medium.com/concourse-ci).
+
+There will then be a two-week quiet period on the RFC. If during this time
+there is a challenge to the resolution, the label will be removed and the RFC
+process will continue. Ideally there are no changes to the RFC during this
+period (all typos should be resolved by now, and wording should be fairly
+clear).
+
+Depending on the resolution, the following will happen to the RFC pull request:
+
+* `resolution/merge`: the PR will be merged!
+* `resolution/postpone`: the PR will be closed and stamped with a `postponed`
+  label. At some point in the future the pull request may be re-opened.
+* `resolution/close`: the PR will be closed with no additional label.
+
+
+## Implementing an RFC
+
+Once an RFC is accepted, an associated issue will be opened on the [`concourse`
+repository](https://github.com/concourse/concourse) repository, referencing the
+RFC's pull request. This issue can be created by the RFC author or assignee.
+
+By the time an RFC is merged, we should have a pretty good idea of who's going
+to implement it. This may or may not be the same person that submitted the RFC.
+Large-scale proposals for example may be picked up by the core Concourse team
+instead (but obviously that'd be something we agree on prior to merging).
+
+The implementation process itself falls under the normal [Concourse development
+process](https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md).
+
+
+## License
+
+All RFCs, and any accompanying code and example content, will fall under the
+Apache v2 license present at the root of this repository.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ requests and issues may be closed with a polite request to submit an RFC first.
 
 If you're not sure whether to open an RFC for a change you'd like to propose,
 feel free to discuss beforehand in [Discord](https://discord.gg/MeRxXKW) - just
-ping \code{@rfc-czars} or guauge interest in \code{#contributors}.
+ping `@rfc-czars` or guauge interest in `#contributors`.
 
 
 ## Providing feedback to an RFC

--- a/README.md
+++ b/README.md
@@ -1,21 +1,25 @@
 # Concourse RFCs
 
-> A process for collaborating on the design for substantial changes to Concourse.
+A process for collaborating on substantial changes to Concourse.
 
 
 ## What should be proposed as an RFC?
 
 RFCs should be opened for changes that have a substantial impact on Concourse
-users and developers. The RFC process enables us to collaborate during the
-design process, before we get to code and implementation.
-
-An important goal of this process is to keep a record of the decision-making
-process as a proposal evolves. This is done via the pull request review and
-commenting system. This allows discussions to be marked as "resolved", rather
-than wrangling an ever-growing comment chain on a GitHub issue.
+users and contributors. RFCs enable the community to collaborate during the
+architecture and feature design process, before getting to code and
+implementation.
 
 
-## RFC Process
+## Providing feedback to an RFC
+
+This process is centered around pull requests. Feedback and questions should be
+left as comments on specific lines of the pull request's proposal document, so
+that they can be marked as resolved. This is to avoid an ever-growing comment
+thread at the top level.
+
+
+## Submitting an RFC
 
 1. Fork this repository.
 1. Copy the `000-example` RFC template, naming it something like

--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@ than wrangling an ever-growing comment chain on a GitHub issue.
 1. Fork this repository.
 1. Copy the `000-example` RFC template, naming it something like
    `123-my-proposal`.
-  * Don't worry too much about the number; they don't have to be sequential.
-    You can try to predict your pull request number for example, and/or just
-    edit it after submitting.
+    * Don't worry too much about the number; they don't have to be sequential.
+      You can try to predict your pull request number for example, and/or just
+      edit it after submitting.
 1. Write your RFC in `proposal.md` under your RFC directory.
-    * Try to outline the motivation for the proposal first. A proposal with
-      no context is more likely to fall under scrutiny.
-    * Having a summary near the beginning of the proposal is also helpful.
-    * Take special care to think about any risks or drawbacks to your proposal
-      ahead-of-time. These have to be assessed at some point! If you're not
-      sure how to resolve them, leave them under an "open questions" section,
-      and we can all try to work through them together.
+      * Try to outline the motivation for the proposal first. A proposal with
+        no context is more likely to fall under scrutiny.
+      * Having a summary near the beginning of the proposal is also helpful.
+      * Take special care to think about any risks or drawbacks to your
+        proposal ahead-of-time. These have to be assessed at some point! If
+        you're not sure how to resolve them, leave them under an "open
+        questions" section, and we can all try to work through them together.
 1. Submit a pull request. Your proposal may include any dependent assets
    (example content, screenshots) under its RFC directory. For convenience,
    link to the rendered proposal in the pull request body, like so:
@@ -49,10 +49,10 @@ than wrangling an ever-growing comment chain on a GitHub issue.
    lines in the pull request and submitting reviews. This allows conversations
    to be marked "resolved" and prevents the comment history on the pull request
    from growing larger and larger.
-  * As the RFC author, feel free to leave your own comments/feedback, using the
-    pull request as a "captain's log" as you think about the problem more and
-    reach key decisions. The point of all this is to have a clear public record
-    for the decision-making process.
+    * As the RFC author, feel free to leave your own comments/feedback, using
+      the pull request as a "captain's log" as you think about the problem more
+      and reach key decisions. The point of all this is to have a clear public
+      record for the decision-making process.
 1. Amendments to the RFC should be made by pushing more commits to the RFC
    branch. **Please do not rebase and force-push over your own commits.**
    Instead, try to make meaningful commits that summarize their changes.

--- a/README.md
+++ b/README.md
@@ -28,13 +28,17 @@ thread at the top level.
       You can try to predict your pull request number for example, and/or just
       edit it after submitting.
 1. Write your RFC in `proposal.md` under your RFC directory.
-      * Try to outline the motivation for the proposal first. A proposal with
-        no context is more likely to fall under scrutiny.
-      * Having a summary near the beginning of the proposal is also helpful.
-      * Take special care to think about any risks or drawbacks to your
-        proposal ahead-of-time. These have to be assessed at some point! If
-        you're not sure how to resolve them, leave them under an "open
-        questions" section, and we can all try to work through them together.
+      * Try to paint a clear mental picture of the motivation for the proposal
+        first. A proposal with no context is more likely to fall under
+        scrutiny.
+      * Having a summary near the beginning of the proposal is also helpful,
+        and if your proposal defines new terms, explicitly listing those
+        up-front is also a good idea.
+      * Take special care to think about any risks, side effects, or drawbacks
+        to your proposal ahead-of-time. These have to be assessed at some
+        point! If you're not sure how to resolve them, leave them under an
+        "open questions" section, and we can all try to work through them
+        together.
 1. Submit a pull request. Your proposal may include any dependent assets
    (example content, screenshots) under its RFC directory. For convenience,
    link to the rendered proposal in the pull request body, like so:


### PR DESCRIPTION
[Rendered](https://github.com/vito/rfcs/blob/master/README.md)

This is largely inspired by [Rust's RFC process](https://github.com/rust-lang/rfcs).

This also establishes early that all RFCs submitted to this repo will be licensed under Apache 2.