### PR TITLE
RFC: k8s storage

### DIFF
--- a/074-k8s-storage/proposal.md
+++ b/074-k8s-storage/proposal.md
@@ -72,9 +72,13 @@ When implementing a CSI driver for Kubernetes it is helpful to understand when c
 
 ## Proposed Implementation of Baggageclaim as a CSI Driver
 
+Targeting Kubernetes Version 1.19
+
 Follow the recommended deployment strategy from the Kubernetes team [described in this design document](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface.md#recommended-mechanism-for-deploying-csi-drivers-on-kubernetes) with the following differences:
-- no `external-resizer` container
-- no `external-snapshotter` container
+- no `external-resizer` container. Not planning to support resizing.
+- no `external-snapshotter` container. We will use the `CLONE_VOLUME` feature to create COW volumes in baggageclaim instead of trying to use snapshots.
+- An extra volume must be mounted for each Pod in the DaemonSet. This volume, which should be very large, will be used by baggageclaim to store the volumes that it creates on each Kubernetes node.
+- We plan to not guarantee the requested storage capicity because we have no idea how much space any given step in Concourse will use. Kubernetes will force us to specify a storage request but our CSI driver will ignore this value.
 
 
 # Storage Options considered

--- a/074-k8s-storage/proposal.md
+++ b/074-k8s-storage/proposal.md
@@ -31,6 +31,8 @@ Furthermore, the CSI is a useful interface for building the storage component ag
 
 ## Level Setting
 
+Before getting into the meat of the proposal let's first understand level set on our understanding of [baggageclaim]() and the [CSI spec]().
+
 ### What does Baggageclaim do?
 
 Baggageclaim comes as two components: a client and a server communicating over an HTTP REST API. The server component manages volumes within a specified directory on the host.
@@ -219,6 +221,7 @@ Still in `NodePublishVolume`, the volume will then be mounted at the path provid
   - What is the recommended way for a CSI controller to maintain state and know which volume is on which node(s)?
 - What is the recommended way to deploy the CSI driver? (e.g. StatefulSet, DaemonSet, etc.) _StatefulSet appears to fit our usecase best_
 - For volume streaming, should we go for the in-cluster P2P solution or stick with streaming through the Concourse web nodes?
+- Does the CSI driver need to be aware of each Concourse cluster that is using it? Another way of phrasing this question: can/should the CSI driver support multiple concourse installations? Do we need to do anything special to support this if we decide yes?
 
 
 # Answered Questions

--- a/074-k8s-storage/proposal.md
+++ b/074-k8s-storage/proposal.md
@@ -1,0 +1,174 @@
+# Terms
+- **cache object** a BLOB and relevant metadata that Concourse needs to persist. These could be Resource Caches, Task Caches or Build Caches.
+- **worker** Concourse executes steps on a **worker** and implements some **worker** interface. Concourse is agnostic of the runtime representation of the worker (eg. K8s pod, node or cluster).
+
+# Summary
+
+After spiking on a few solutions for storage on Kubernetes our recommendation is to use an image registry to store **cache objects** for steps.
+
+# Motivation
+
+As we started thinking about the Kubernetes runtime we realized that we need to think about what our storage solution would be before proceeding with any other part of the implementation. Storage has a huge effect on how Concourse interacts with the runtime (Kubernetes). Storage also had a lot of unknowns, we didn't know what the storage landscape on Kubernetes looked like and what options were available to us. Storage also has a huge impact on the perforamnce of the cluster, in regards to storage and initialization of steps.
+
+## Requirements
+An ideal storage solution can do the following :
+
+- image fetching from the CRI k8s is using
+- transfer **cache objects** between steps (whatever represents a step, most likely a pod)
+- cache for resources and tasks
+- stream **cache objects** across worker runtimes (k8s worker sends artifact to garden worker)
+
+## Criteria
+- security
+- performance, aka initialization time (time spent running workloads on a single k8s worker, as well as across workers)
+- resource usage to run this storage solution
+
+# Proposal
+
+**TL;DR**: We recommend going with the image registry option because it satisfies all the requirements and gives us a bunch of options to improve performance when compared to the blobstore option. It also provides a very flexible solution that works across multiple runtime workers. [See Details TODO](#image-registry-to-store-artifacts)
+
+Furthermore, the CSI is a useful interface for building the storage component against. [See Details TODO](#csi)
+
+# Storage Options considered
+## Baggageclaim Daemonset 
+### Description
+A privileged baggageclaim pod would manage all the **cache object** for step pods. The pod can be provided sufficient privilege to create overlay mounts using `BiDirectional` value for `mountPropagation`. The `volumeMount` object allows specifying a volume `subPath`.
+
+This approach didn't work using GCE PDs or vSphere Volumes ([Issue](https://github.com/kubernetes/kubernetes/issues/95049)). It does work using `hostPath` option, however, that would require a large root volume and wouldn't be able to leverage IaaS based persistent disks. 
+
+The pod would run on all nodes that Concourse would execute steps on.
+ 
+### Pros
++ Leverage baggageclaim
+	+ volume streaming between nodes would work using the current Concourse architecture
+	+ resource and task caches would also work using the current Concourse architecture
+	+ would be able to stream **cache objects** across worker runtimes as it would be mediated via the web
++ Concourse would have complete control over volume lifecycle
++ would have negligible overhead for steps scheduled on the same node as no input/output stream would be required
+
+### Cons
+- Not being able to use IaaS based persisent disks doesn't offer a viable solution. K8s nodes would need to have large root volumes.
+- Wouldn't have support for hosting images by default. However, `baggageclaim` could be extended to add the APIs
+- `baggageclaim` itself doesn't have any authentication/authorization or transport security (https) mechanisms built into it
+
+## Image Registry to store artifacts
+### Description
+Each **cache object** is represented as a image layer for a repository in an image registry. [SPIKE using registry to store artifacts](https://github.com/concourse/concourse/issues/3740). Concourse would require a managed image registry as a dependency. For each step, Concourse would generate a image config and manifest with all the relevant inputs modeled as image layers. 
+
+### Pros
+- Would have support for building an image in a step and using it as the image for a subsequent step. This would require the image registry to be accessible by the CRI subsystem on a node
+- Image registries are are critical to operating on K8s and as such there are plenty of options for leveraging managed IaaS based solutions such as GCR, ECR, ACR to on prem solutions like Harbor. Therefore, it would be a safe assumption that a Concourse on K8s user would already have a registry available for use.
+- Could explore further de-coupling by exploring [csi-driver-image-populator](https://github.com/kubernetes-csi/csi-driver-image-populator) when using registries for storing artifacts. Listed as a sample driver in the CSI docs and README says it is not production ready. Last commit was Oct 2019. There is also another utility - [imgpack](https://github.com/k14s/imgpkg) which allows arbitrary data store in images as layers.
+- Leverage performance enhancements to registries such as [pull through cache](https://docs.docker.com/registry/recipes/mirror/)
+- Use a standardized and documented [OCI image-spec protocol](https://github.com/opencontainers/image-spec)
+- LRU based local caching of image layers by the K8s CRI
+- Established ways of securely pushing/pulling blobs from an image registry
+- As this would be a centralized storage solution
+	- it doesn't impact what a K8s based Concourse worker looks like
+	- Simplified GC
+	- Would support streaming across worker runtimes
+	
+### Cons
+- Some registries such as GCR don't expose an API to delete layers directly
+- **cache object** would have to have a fixed static path in the image file system to be able to reuse the same layer. This would require some additional handling on Concourse to support [input-mapping](https://concourse-ci.org/jobs.html#schema.step.task-step.input_mapping) and [output-mapping](https://concourse-ci.org/jobs.html#schema.step.task-step.output_mapping)
+- Adds extra development overhead to generate new image config & manifests to leverage **cache object** layers
+- Adds extra initialization overhead. Concourse wouldn't have control over the local caches on K8s nodes, so volumes would always have to be pushed to the centralized registry and pulled at least once when executing a step
+- Potentially adds substantial load on registry, as Concourse would be creating a new file system layer for every **cache object**
+- There isn't a well documented approach to setup an in-cluster secure registry. The setup requires exposing an in-cluster registry externally with traffic routed via an LB. [Prior spike](https://github.com/concourse/concourse/issues/3796)
+
+## S3 Compatible Blobstore
+## Description
+Each **cache object** is stored in a blobstore. Concourse would require a mananaged blobstore as a dependency. For each step, Concourse would pull down the relevant blobs for inputs and push blobs for outputs. 
+
+### Pros
+- Scale well (GCR uses GCS as the underlying storage)
+- Could explore further de-coupling by exploring CSI driver
+- Established ways of securely fetching/pushing blobs from an a blobstore
+- As this would be a centralized storage solution
+	- it doesn't impact what a K8s based Concourse worker looks like
+	- Simplified GC
+	- Would support streaming across worker runtimes
+	
+### Cons
+- Wouldn't have support for hosting images by default.
+- Adds another dependency for Concourse (depending on where Concourse is deployed there might be managed solutions available) 
+- Lack of standardized APIs
+- Adds extra initialization overhead. Concourse wouldn't have a local cache, so volumes would always have to be pushed & pulled for steps
+- Concourse would potentially be heavy user of the blobstore
+
+## Persistent Volumes
+Each **cache object** would be stored in its own persistent volume. Persistent volume snapshots would be used to reference **cache object** versions.
+
+### Pros
+- Would leverage native k8s offering
+- Maps well to Concourse's use of **cache objects** and offloads the heavy lifting to K8s
+- Potentially wouldn't require volumes to be streamed at all
+
+### Cons
+- Wouldn't have support for hosting images by default.
+- IaaS based limits on [volume limits per node](https://kubernetes.io/docs/concepts/storage/storage-limits/#dynamic-volume-limits) prevents this from being a scalable solution
+- CSI Snapshotting feature is optional and not every driver supports it (LINK)
+- As this would NOT be a centralized storage solution, it wouldn't support workers across multiple runtimes or even K8s clusters
+
+## K8s POC (Baggagelciam peer-to-peer)
+Each step would have a sidecar container to populate input **cache objects** and host outputs **cache objects** via an HTTP API.`beltloader` is used to populate inputs. `baggageclaim` is used to host outputs. `baggageclaim` was also modified to allow **cache objects** to be accessed via the registry APIs (support images).
+
+### Pros
+- No external dependencies are required
+- Supports worker-to-worker streaming bypassing Concourse web
+
+### Cons
+- the `step` pod's lifecycle is tied to the **cache object** lifecycle (pods have to be kept around until the **cache object** they host is required). This would increase the CPU & memory usage of a cluster. 
+- there isn't a simple mechanism to allow the k8s container runtime to securely access the `baggageclaim` endpoints to fetch images
+- As this would NOT be a centralized storage solution, it would require exposing the `baggageclaim` endpoints via `services` to be accessed externally
+- `baggageclaim` itself doesn't have any authentication/authorization or transport security (https) mechanisms built into it
+
+# Other considerations
+## CSI 
+The [Container Storage Interface](https://github.com/container-storage-interface/spec/blob/master/spec.md) provides a generic interface for providing storage to containers.
+
+CSI was developed as a standard for exposing arbitrary block and file storage storage systems to containerized workloads on Container Orchestration Systems (COs) like Kubernetes. With the adoption of the Container Storage Interface, the Kubernetes volume layer becomes truly extensible. Using CSI, third-party storage providers can write and deploy plugins exposing new storage systems in Kubernetes without ever having to touch the core Kubernetes code. This gives Kubernetes users more options for storage and makes the system more secure and reliable. [Source](https://kubernetes.io/blog/2019/01/15/container-storage-interface-ga/#why-csi)
+
+The CSI spec can be used to wrap every solution listed above. It provides an API through which the chosen solution would be consumed.
+
+### Pros
+- Can be deployed/managed using k8s resources ([hostPath CSI Driver example](https://github.com/kubernetes-csi/csi-driver-host-path/blob/master/docs/deploy-1.17-and-later.md))
+- Allows the storage mechanims to be swapped more easily
+	- can be an extension point for Concourse community
+- De-couples Concourse from its usage of storage
+	- the driver could be patched/upgraded indepdently of Concourse 
+- The CSI Spec is quite flexible and has a minimum set of required methods (the other set of features are opt-in)
+- CSI supports multiple deployment topologies (master, master+node, node)
+- Provides a scheduling extension point for volume aware scheduling
+
+### Cons
+- extra overhead for development, packaging and deployment
+- the CSI version may be tied to a K8s version
+
+## Fuse
+This might simplify our usage of external storage solutions such as blobstores. There isn't a supported solution in K8s at the moment. However, this would be something worth considering if that were to change. Current [issue requesting K8s development](## Fuse
+https://github.com/kubernetes/kubernetes/issues/7890)
+
+# Open Questions
+
+> Raise any concerns here for things you aren't sure about yet.
+- Do we implement our own version of the csi-image-populator?
+- Should we implement this as a CSI driver?
+
+
+# Answered Questions
+
+> If there were any major concerns that have already (or eventually, through
+> the RFC process) reached consensus, it can still help to include them along
+> with their resolution, if it's otherwise unclear.
+>
+> This can be especially useful for RFCs that have taken a long time and there
+> were some subtle yet important details to get right.
+>
+> This may very well be empty if the proposal is simple enough.
+
+
+# New Implications
+
+> What is the impact of this change, outside of the change itself? How might it
+> change peoples' workflows today, good or bad?

--- a/074-k8s-storage/proposal.md
+++ b/074-k8s-storage/proposal.md
@@ -25,9 +25,9 @@ An ideal storage solution can do the following :
 
 # Proposal
 
-**TL;DR**: We recommend going with the image registry option because it satisfies all the requirements and gives us a bunch of options to improve performance when compared to the blobstore option. It also provides a very flexible solution that works across multiple runtime workers. [See Details TODO](#image-registry-to-store-artifacts)
+**TL;DR**: We recommend going with the image registry option because it satisfies all the requirements and gives us a bunch of options to improve performance when compared to the blobstore option. It also provides a very flexible solution that works across multiple runtime workers. [See Details](#image-registry-to-store-artifacts)
 
-Furthermore, the CSI is a useful interface for building the storage component against. [See Details TODO](#csi)
+Furthermore, the CSI is a useful interface for building the storage component against. [See Details](#csi)
 
 # Storage Options considered
 ## Baggageclaim Daemonset 

--- a/074-k8s-storage/proposal.md
+++ b/074-k8s-storage/proposal.md
@@ -230,6 +230,7 @@ Here are two potential paths Concourse could take to address this use-case. More
   - How will Concourse stream single files in a volume? (i.e. when Concourse needs to read a task config from the artifact of a get step)
 - Does the CSI driver need to be aware of each Concourse cluster that is using it? Another way of phrasing this question: can/should the CSI driver support multiple concourse installations? Do we need to do anything special to support this if we decide yes?
 - Do we need to modify baggageclaim for any reason?
+- Adding image regisrty endpoints to baggageclaim so we can still support using images from a previous step? Was thinking that we could add the endpoints like Ciro did in the POC. Our baggageclaim pods will already be on each k8s node in a privileged volume. Would it be wrong to add in a cert for each baggageclaim registry so that the CRI's on all nodes can reach our baggageclaim image registry? [Trow has figured out how to add a cert](https://github.com/ContainerSolutions/trow/blob/7e3187edbdc8c37c836a2cdc133fd6c68289b11e/quick-install/install.sh#L138-L146)
 
 
 # Answered Questions

--- a/074-k8s-storage/proposal.md
+++ b/074-k8s-storage/proposal.md
@@ -8,7 +8,7 @@ After spiking on a few solutions for storage on Kubernetes our recommendation is
 
 # Motivation
 
-As we started thinking about the Kubernetes runtime we realized that we need to think about what our storage solution would be before proceeding with any other part of the implementation. Storage has a huge effect on how Concourse interacts with the runtime (Kubernetes). Storage also had a lot of unknowns, we didn't know what the storage landscape on Kubernetes looked like and what options were available to us. Storage also has a huge impact on the perforamnce of the cluster, in regards to storage and initialization of steps.
+As we started thinking about the Kubernetes runtime we realized that we need to think about what our storage solution would be before proceeding with any other part of the implementation. Storage has a huge effect on how Concourse interacts with the runtime (Kubernetes). Storage also had a lot of unknowns, we didn't know what the storage landscape on Kubernetes looked like and what options were available to us. Storage also has a huge impact on the performance of the cluster, in regards to storage and initialization of steps.
 
 ## Requirements
 An ideal storage solution can do the following :
@@ -151,24 +151,18 @@ https://github.com/kubernetes/kubernetes/issues/7890)
 
 # Open Questions
 
-> Raise any concerns here for things you aren't sure about yet.
 - Do we implement our own version of the csi-image-populator?
 - Should we implement this as a CSI driver?
 
 
 # Answered Questions
 
-> If there were any major concerns that have already (or eventually, through
-> the RFC process) reached consensus, it can still help to include them along
-> with their resolution, if it's otherwise unclear.
->
-> This can be especially useful for RFCs that have taken a long time and there
-> were some subtle yet important details to get right.
->
-> This may very well be empty if the proposal is simple enough.
+
+# Related Links
+- [Storage Spike](https://github.com/concourse/concourse/issues/6036)
+- [Review k8s worker POC](https://github.com/concourse/concourse/issues/5986)
 
 
 # New Implications
 
-> What is the impact of this change, outside of the change itself? How might it
-> change peoples' workflows today, good or bad?
+Will drive the rest of the Kubernetes runtime work.

--- a/074-k8s-storage/proposal.md
+++ b/074-k8s-storage/proposal.md
@@ -146,8 +146,7 @@ The CSI spec can be used to wrap every solution listed above. It provides an API
 - the CSI version may be tied to a K8s version
 
 ## Fuse
-This might simplify our usage of external storage solutions such as blobstores. There isn't a supported solution in K8s at the moment. However, this would be something worth considering if that were to change. Current [issue requesting K8s development](## Fuse
-https://github.com/kubernetes/kubernetes/issues/7890)
+This might simplify our usage of external storage solutions such as blobstores. There isn't a supported solution in K8s at the moment. However, this would be something worth considering if that were to change. [Click here to view the current issue requesting K8s development](https://github.com/kubernetes/kubernetes/issues/7890).
 
 # Open Questions
 

--- a/074-k8s-storage/proposal.md
+++ b/074-k8s-storage/proposal.md
@@ -219,10 +219,11 @@ Still in `NodePublishVolume`, the volume will then be mounted at the path provid
 - What does the Concourse database model for volumes look like with a k8s worker running a baggageclaim CSI driver?
 - How will the CSI driver stream a volume between k8s nodes?
   - What is the recommended way for a CSI controller to maintain state and know which volume is on which node(s)?
-  - How will we stream single files in a volume? (i.e. when Concourse needs to read a task config from the artifact of a get step)
+  - How will we stream single files in a volume? (i.e. when Concourse needs to read a task config from the artifact of a get step) (maybe this is an open question for the runtime RFC)
 - What is the recommended way to deploy the CSI driver? (e.g. StatefulSet, DaemonSet, etc.) _StatefulSet appears to fit our usecase best_
 - For volume streaming, should we go for the in-cluster P2P solution or stick with streaming through the Concourse web nodes?
 - Does the CSI driver need to be aware of each Concourse cluster that is using it? Another way of phrasing this question: can/should the CSI driver support multiple concourse installations? Do we need to do anything special to support this if we decide yes?
+- Do we need to modify baggageclaim for any reason?
 
 
 # Answered Questions

--- a/074-k8s-storage/proposal.md
+++ b/074-k8s-storage/proposal.md
@@ -96,6 +96,14 @@ Each **cache object** is stored in a blobstore. Concourse would require a manana
 - Adds extra initialization overhead. Concourse wouldn't have a local cache, so volumes would always have to be pushed & pulled for steps
 - Concourse would potentially be heavy user of the blobstore
 
+## Baggageclaim + CSI Implementation
+### Description
+TODO
+### Pros
+TODO
+### Cons
+TODO
+
 ## Persistent Volumes
 Each **cache object** would be stored in its own persistent volume. Persistent volume snapshots would be used to reference **cache object** versions.
 

--- a/074-k8s-storage/proposal.md
+++ b/074-k8s-storage/proposal.md
@@ -107,7 +107,7 @@ Each **cache object** would be stored in its own persistent volume. Persistent v
 ### Cons
 - Wouldn't have support for hosting images by default.
 - IaaS based limits on [volume limits per node](https://kubernetes.io/docs/concepts/storage/storage-limits/#dynamic-volume-limits) prevents this from being a scalable solution
-- CSI Snapshotting feature is optional and not every driver supports it (LINK)
+- CSI Snapshotting feature is optional and not every driver supports it ([Drivers & features they support](https://kubernetes-csi.github.io/docs/drivers.html#production-drivers))
 - As this would NOT be a centralized storage solution, it wouldn't support workers across multiple runtimes or even K8s clusters
 
 ## K8s POC (Baggagelciam peer-to-peer)

--- a/074-k8s-storage/proposal.md
+++ b/074-k8s-storage/proposal.md
@@ -155,16 +155,24 @@ This might simplify our usage of external storage solutions such as blobstores. 
 
 # Open Questions
 
-- Do we implement our own version of the csi-image-populator?
-- Should we implement this as a CSI driver?
+- When we need to have a volume available on multiple k8s nodes, how do we do this in a baggageclaim CSI driver?
+  - Would it make sense to support `ReadWriteMany` as the volume's `accessMode` instead of `ReadWriteOnce`?
+- What does the Concourse database model for volumes look like with a k8s worker running a baggageclaim CSI driver?
+- How will the CSI driver stream a volume between k8s nodes?
+  - What is the recommended way for a CSI controller to maintain state and know which volume is on which node(s)?
+- What is the recommended way to deploy the CSI driver? (e.g. StatefulSet, DaemonSet, etc.) _StatefulSet appears to fit our usecase best_
+- For volume streaming, should we go for the in-cluster P2P solution or stick with streaming through the Concourse web nodes?
 
 
 # Answered Questions
 
+- Should we implement this as a CSI driver? **Yes we do after doing the CSI Driver POC Spike**
+- Do we implement our own version of the csi-image-populator? **Yes but based on baggageclaim instead of image layers**
 
 # Related Links
 - [Storage Spike](https://github.com/concourse/concourse/issues/6036)
 - [Review k8s worker POC](https://github.com/concourse/concourse/issues/5986)
+- [CSI Driver POC Spike](https://github.com/concourse/concourse/issues/6133)
 
 
 # New Implications

--- a/074-k8s-storage/proposal.md
+++ b/074-k8s-storage/proposal.md
@@ -219,6 +219,7 @@ Still in `NodePublishVolume`, the volume will then be mounted at the path provid
 - What does the Concourse database model for volumes look like with a k8s worker running a baggageclaim CSI driver?
 - How will the CSI driver stream a volume between k8s nodes?
   - What is the recommended way for a CSI controller to maintain state and know which volume is on which node(s)?
+  - How will we stream single files in a volume? (i.e. when Concourse needs to read a task config from the artifact of a get step)
 - What is the recommended way to deploy the CSI driver? (e.g. StatefulSet, DaemonSet, etc.) _StatefulSet appears to fit our usecase best_
 - For volume streaming, should we go for the in-cluster P2P solution or stick with streaming through the Concourse web nodes?
 - Does the CSI driver need to be aware of each Concourse cluster that is using it? Another way of phrasing this question: can/should the CSI driver support multiple concourse installations? Do we need to do anything special to support this if we decide yes?


### PR DESCRIPTION
[Rendered](https://github.com/concourse/rfcs/blob/074-k8s-storage/074-k8s-storage/proposal.md)

This is meant for the next iteration of our Kubernetes runtime work. **This has nothing to do with how the Concourse helm chart currently functions**.