### PR TITLE
075 k8s runtime

### DIFF
--- a/075-k8s-runtime/proposal.md
+++ b/075-k8s-runtime/proposal.md
@@ -64,12 +64,18 @@ Ideally, each instance of the component should have its own unique identity.
 1. 1 K8s worker & Concourse web external (Simpler for local development)
   + register worker
   + heartbeat
+1. Fly workers
+1. Fly containers
+1. Fly volumes
 1. Pod GC'ing - only delete pods we know about. Ignore other pods.
 1. 1 K8s worker & Concourse web in-cluster
 1. Image Registry GC'ing
 1. Worker retiring/landing
   + fly land-worker
   + fly prune-worker
+1. Tracing
+1. Metrics (Placeholder)
+1. Default K8s container placement strategy
 
 ## Developer Use Cases
 1. Hello World (without `image_resource`)
@@ -143,6 +149,8 @@ Ideally, each instance of the component should have its own unique identity.
   + upload inputs
   + image from a pipeline->job->step
   + outputs
+
+1. Fly watch
 
 1. Fly Hijack
 

--- a/075-k8s-runtime/proposal.md
+++ b/075-k8s-runtime/proposal.md
@@ -14,6 +14,8 @@ Same as the [k8s POC](https://github.com/concourse/concourse/issues/5209), imple
 ### Other Options
 * Behind the Garden API, similar to `containerd`. [More details in our review of the k8s POC](https://github.com/concourse/concourse/issues/5986#issuecomment-675061559).
 
+## Step to Pod Mapping [TODO]
+
 ## Coordinating Container Execution
 As a starting point, do something similar to the [k8s POC](https://github.com/concourse/concourse/issues/5209), use an `init` binary to keep the Pod from being deleted. ATC then monitors the state of the running Pods and executes actions on those Pods. The storage solution we end up going with will be a heavy driver of how we end up coordinating container execution with fetching and saving inputs/outputs.
 

--- a/075-k8s-runtime/proposal.md
+++ b/075-k8s-runtime/proposal.md
@@ -84,6 +84,8 @@ Ideally, each instance of the component should have its own unique identity.
               path: echo
               args: ["Hello, world!"]
   ```
+  + Task with params
+
 1. Hello World (2 tasks with inputs/outputs,without `image_resource`)
   ```
   ---
@@ -117,6 +119,25 @@ Ideally, each instance of the component should have its own unique identity.
               args:
                 - ./files/created_file
   ```
+  + Task with output
+  + Task with input
+  + Input mapping
+  + Output mapping
+  + Task cache
+  + Container limits
+  + rootfs_uri ?
+
+1. Fly Execute
+  + `params`
+  + worker `tag`
+  + `--inputs-from`
+  + upload inputs
+  + image from a pipeline->job->step
+  + outputs
+
+
+1. Fly Hijack
+
 1. Booklit Sample (Resources support)
   ```
   resources:
@@ -140,7 +161,9 @@ Ideally, each instance of the component should have its own unique identity.
         run:
           path: booklit/ci/test
   ```
-  + Booklit with params
+  + Check step
+  + Get step
+  + Put step
 
 1. Hello World (Add support for `image_resource`)
   ```
@@ -162,7 +185,8 @@ Ideally, each instance of the component should have its own unique identity.
 
 1. 2 steps tagged with 2 workers
 1. 2 steps tagged with 2 workers on different runtimes (K8s + containerd)
-
+1. Hello World ( Windows platform )
+1. Resources ( Windows platform )
 
 
 

--- a/075-k8s-runtime/proposal.md
+++ b/075-k8s-runtime/proposal.md
@@ -43,25 +43,139 @@ The **Worker Lifecycle component** would be responsible for the following;
   * **Retir(ing/ed)**: Stop scheduling workloads on the worker.
   * **Container GC**: Worker would be responsible for cleaning up step pods that are no longer required by the web
   * **Volume GC**: Worker would be responsible for cleaning up local **cache objects** that are no longer required by the web. 
+  * **Base Resources**: The Worker would advertise these base resources. This definition would include the list of base resources and their registry & repository metadata (eg. imagePullSecrets)
 
 ## Image Registry Lifecycle
 The **image registry lifecycle component** would be responsible for;
   * **Volume GC**: would be responsible for cleaning up global **cache objects** that are no longer required by the web. How this works will depend on our storage solution.
 
 ## Authenticating to the k8s worker
-
+Concourse would support both mechanisms for authenticating to the k8s cluster
+- kubeconfig
+- service account
 
 ## Authenticating to the web API
 The **Worker Lifecycle Component** should have its own identity (client id & secret) to communicate with the web API securely. 
 
 Ideally, each instance of the component should have its own unique identity. 
 
+# Milestones
+## Operator Use Cases
+1. 1 K8s worker & Concourse web external (Simpler for local development)
+1. Pod GC'ing
+1. 1 K8s worker & Concourse web in-cluster
+1. Image Registry GC'ing
+1. Worker retiring/landing
+## Developer Use Cases
+1. Hello World (without `image_resource`)
+  ```
+  ---
+  jobs:
+    - name: job
+      public: true
+      plan:
+        - task: simple-task
+          config:
+            platform: linux
+            image_resource:
+              type: registry-image
+              source: { repository: busybox }
+            run:
+              path: echo
+              args: ["Hello, world!"]
+  ```
+1. Hello World (2 tasks with inputs/outputs,without `image_resource`)
+  ```
+  ---
+  jobs:
+    - name: create-and-consume
+      public: true
+      plan:
+        - task: make-a-file
+          config:
+            platform: linux
+            image_resource:
+              type: registry-image
+              source: { repository: busybox }
+            run:
+              path: sh
+              args:
+                - -exc
+                - ls -la; echo "Created a file on $(date)" > ./files/created_file
+            outputs:
+              - name: files
+        - task: consume-the-file
+          config:
+            platform: linux
+            image_resource:
+              type: registry-image
+              source: { repository: busybox }
+            inputs:
+              - name: files
+            run:
+              path: cat
+              args:
+                - ./files/created_file
+  ```
+1. Booklit Sample (Resources support)
+  ```
+  resources:
+  - name: booklit
+    type: git
+    source: {uri: "https://github.com/vito/booklit"}
+
+  jobs:
+  - name: unit
+    plan:
+    - get: booklit
+      trigger: true
+    - task: test
+      config:
+        platform: linux
+        image_resource:
+          type: registry-image
+          source: {repository: golang}
+        inputs:
+        - name: booklit
+        run:
+          path: booklit/ci/test
+  ```
+  + Booklit with params
+
+1. Hello World (Add support for `image_resource`)
+  ```
+  ---
+  jobs:
+    - name: job
+      public: true
+      plan:
+        - task: simple-task
+          config:
+            platform: linux
+            image_resource:
+              type: registry-image
+              source: { repository: busybox }
+            run:
+              path: echo
+              args: ["Hello, world!"]
+  ```
+
+1. 2 steps tagged with 2 workers
+1. 2 steps tagged with 2 workers on different runtimes (K8s + containerd)
+
+
+
+
 # Open Questions
 
 * How should [worker `tags`](https://concourse-ci.org/concourse-worker.html#worker-configuration) be used? Should we pass the tag down to Kubernetes as the node name or not pass it down at all?
   * Current Thoughts: We should not pass the tag down to Kubernetes. Tags are used in Concourse to select a set of workers and if we are treating Kubernetes as a worker then it should not operate on the tag(s) like workers currently behave.
 * Worker lifecycle: With volumes being stored in an image registry volumes are no longer associated with a specific worker. Should we change what it means to "Retire" a worker? This will be driven out by how we develop the storage solution.
+* Worker lifecycle: Should/could this component be run as a standalone component ?
+  * The benefit of doing so would allow it to be managed separately from Concourse web. Scaling the web nodes is independent to scaling the worker lifecycle component. 
 * Today the TSA component provides two services: 1) securing communication to and from the worker and 2) allowing a public web instance to talk to a woker inside a private network. With a Kubernetes worker communication is already secure. Is there some third-party tool we can leverage to achieve the second service that TSA currently provides us?
+* Container Execution: Where do we store task step status similar to updating garden container properties to store exit status ?
+* Authenticating to the k8s workder: How do we support different auth provdiers ?
 
 # Answered Questions
 

--- a/075-k8s-runtime/proposal.md
+++ b/075-k8s-runtime/proposal.md
@@ -62,10 +62,15 @@ Ideally, each instance of the component should have its own unique identity.
 # Milestones
 ## Operator Use Cases
 1. 1 K8s worker & Concourse web external (Simpler for local development)
-1. Pod GC'ing
+  + register worker
+  + heartbeat
+1. Pod GC'ing - only delete pods we know about. Ignore other pods.
 1. 1 K8s worker & Concourse web in-cluster
 1. Image Registry GC'ing
 1. Worker retiring/landing
+  + fly land-worker
+  + fly prune-worker
+
 ## Developer Use Cases
 1. Hello World (without `image_resource`)
   ```
@@ -85,6 +90,10 @@ Ideally, each instance of the component should have its own unique identity.
               args: ["Hello, world!"]
   ```
   + Task with params
+  + Container limits
+  + Privileged container
+  + fly abort
+  + stream/capture stdout & stderr
 
 1. Hello World (2 tasks with inputs/outputs,without `image_resource`)
   ```
@@ -124,8 +133,7 @@ Ideally, each instance of the component should have its own unique identity.
   + Input mapping
   + Output mapping
   + Task cache
-  + Container limits
-  + Privileged container
+  + fly clear-task-cache
   + rootfs_uri ?
 
 1. Fly Execute
@@ -150,21 +158,56 @@ Ideally, each instance of the component should have its own unique identity.
     plan:
     - get: booklit
       trigger: true
-    - task: test
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: golang}
-        inputs:
-        - name: booklit
-        run:
-          path: booklit/ci/test
   ```
   + Check step
+    + logs (capture stderr)
+    + abort
   + Get step
-  + Put step
+    + logs (capture stderr)
+    + abort
+
+1. Put step
+  ```
+  resources:
+  - name: booklit
+    type: git
+    source: {uri: "https://github.com/vito/booklit"}
+
+  - name: booklit-dev
+    type: git
+    source:
+      uri: "https://github.com/vito/booklit"
+      branch: dev
+
+  jobs:
+  - name: unit
+    plan:
+    - get: booklit
+      trigger: true
+    - put: booklit-dev
+      params:
+        repository: booklit
+  ```
+
+  + logs (capture stderr)
+  + abort
+
 1. Hello World (`Task.file`)
+
+```
+resources:
+- name: my-repo
+  type: git
+  source: # ...
+
+jobs:
+- name: use-task-file
+  plan:
+  - get: my-repo
+  - task: unit
+    file: my-repo/ci/unit.yml
+```
+  + Task with vars
 
 1. Hello World (Add support for `Task.image`)
 ```
@@ -198,10 +241,10 @@ jobs:
               args: ["Hello, world!"]
   ```
 
-1. 2 steps tagged with 2 workers
-1. 2 steps tagged with 2 workers on different runtimes (K8s + containerd)
-1. Hello World ( Windows platform )
-1. Resources ( Windows platform )
+1. 2 steps tagged with 2 workers (k8s to k8s)
+1. 2 steps tagged with 2 workers on k8s and another runtime (K8s + containerd)
+1. Hello World ( k8s Windows platform )
+1. Resources ( k8s Windows platform )
 
 
 

--- a/075-k8s-runtime/proposal.md
+++ b/075-k8s-runtime/proposal.md
@@ -125,6 +125,7 @@ Ideally, each instance of the component should have its own unique identity.
   + Output mapping
   + Task cache
   + Container limits
+  + Privileged container
   + rootfs_uri ?
 
 1. Fly Execute
@@ -134,7 +135,6 @@ Ideally, each instance of the component should have its own unique identity.
   + upload inputs
   + image from a pipeline->job->step
   + outputs
-
 
 1. Fly Hijack
 
@@ -164,7 +164,22 @@ Ideally, each instance of the component should have its own unique identity.
   + Check step
   + Get step
   + Put step
+1. Hello World (`Task.file`)
 
+1. Hello World (Add support for `Task.image`)
+```
+resources:
+- name: my-image
+  type: registry-image
+  source: {repository: golang, tag: "1.13"}
+
+jobs:
+- name: use-image
+  plan:
+  - get: my-image
+  - task: unit
+    image: my-image
+```
 1. Hello World (Add support for `image_resource`)
   ```
   ---


### PR DESCRIPTION
[Rendered](https://github.com/concourse/rfcs/blob/075-k8s-runtime/075-k8s-runtime/proposal.md)

This is meant for the next iteration of our Kubernetes runtime work. This has nothing to do with how the Concourse helm chart currently functions.